### PR TITLE
fix typo in eva_vit.py

### DIFF
--- a/offsite_tuning/models/eva_vit.py
+++ b/offsite_tuning/models/eva_vit.py
@@ -102,7 +102,7 @@ class Mlp(nn.Module):
         x = self.fc1(x)
         x = self.act(x)
         # x = self.drop(x)
-        # commit this for the orignal BERT implement
+        # commit this for the original BERT implement
         x = self.fc2(x)
         x = self.drop(x)
         return x


### PR DESCRIPTION
orignal -> original